### PR TITLE
Fix minor things, more for discussion

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -2,7 +2,7 @@
 
 \usepackage[utf8]{inputenc}
 \usepackage{url}
-\usepackage{listings}
+\usepackage{minted}
 \usepackage{xspace}
 \usepackage{natbib}  % Requires natbib.sty, available from http://ads.harvard.edu/pubs/bibtex/astronat/
 
@@ -173,7 +173,7 @@ A typical example is given below, where we generate a spectrum and error
 array using \texttt{numpy} and \texttt{astropy} tools.
 
 \begin{minipage}{\linewidth}
-\begin{lstlisting}
+\begin{minted}{python}
 from astropy import units as u
 import numpy as np
 import pyspeckit
@@ -190,7 +190,7 @@ sp = pyspeckit.Spectrum(xarr=xaxis,
 sp.plotter(errstyle='fill')
 
 sp.plotter.savefig("example_fig_1.pdf")
-\end{lstlisting}
+\end{minted}
 \end{minipage}
 
 \begin{figure*}[!htp]

--- a/main.tex
+++ b/main.tex
@@ -42,7 +42,7 @@ community with easy-to-use tools for line fittings, but \texttt{IRAF}
 development has mostly ceased in the last several years and is currently only
 supported in Python 2.7 by
 AstroConda\footnote{http://astroconda.readthedocs.io/en/latest/index.html},
-though the PyRAF command language supports both python 2 and python 3 and is
+though the PyRAF command language supports both Python 2 and Python 3 and is
 still maintained.
 
 [It would be interesting to describe the history and purpose of \pyspeckit and \astropy here] 
@@ -264,7 +264,7 @@ most users, gave them access to those results \emph{only} through the GUI.
 functionality, but with additional means of interacting with the fitter.  In
 \texttt{splot}, reproducing any given fit is challenging, since subtle changes
 in the cursor position can significantly change the fit result.  In \pyspeckit,
-it is possible to record the results of fits programatically and re-fit using
+it is possible to record the results of fits programmatically and re-fit using
 those same results.
 
 The GUI was built using \texttt{matplotlib}'s canvas interaction tools.  These
@@ -278,7 +278,7 @@ publication-quality figures.  The default plotting mode uses histogram-style
 line plots and labels axes with \LaTeX-formatted versions of units.
 
 When the plotter is active and a model is fit, the model parameters are
-displayed with \LaTeX formatting.  The errors on the parameters, if available,
+displayed with \LaTeX~formatting.  The errors on the parameters, if available,
 are also shown, and these errors are used to decide on how many significant
 figures to display.
 

--- a/make.py
+++ b/make.py
@@ -32,7 +32,8 @@ def do_everything():
                 os.remove(fn)
 
     PDFLATEX=os.path.join(args.texpath,'pdflatex')
-    pdflatex_args = "-halt-on-error -synctex=1 --interaction=nonstopmode".split()
+    pdflatex_args = ("-halt-on-error -synctex=1 --interaction=nonstopmode"
+                     " --shell-escape").split()
 
     BIBTEX = os.path.join(args.texpath, 'bibtex')
 


### PR DESCRIPTION
Some immediate fixes of typos and formatting are already in the PR. What follows are comments on the specific parts of the paper.

1. I am confused in this paragraph on the error estimation: "This covariance matrix is not directly the covariance of the parameters, and must be rescaled to deliver an approximate error. The standard rescaling is to multiply the covariance by the sum of the squared errors divided by the degree of freedom of the fit, usually referred to as χ2 /N."
Where does the covariance matrix scaling come from? First of all, isn't Andrae et al. (2010) main point is that the degree of freedom of a nonlinear model is undefined in the first place, even if it is Taylor expansion-friendly? And then, looking at the way lmfit computes the errors, I don't see anything about the covariance matrix rescaling. If an example from https://lmfit.github.io/lmfit-py/model.html is run, then the uncertainties on the parameters turn out to be exactly the `np.sqrt(np.diag(result.covar))`, with no apparent dependence on the reduced chi^2. Does it do it under the hood somewhere?

2. A lot of new users coming from the radio side would be wondering how the molecular line emission profiles are computed. Should we add a section which starts off with a solution of the radiative transfer equation and goes on to explain how a hyperfine structure models are being generated (ideally with an example synthetic spectrum fit)? This echoes the "if this is the beefiest part of pyspeckit" comment closing Section 5.

3. I think this saying that `Cubes.fiteach` "This tool is not the best tested component of pyspeckit" might scare people off! It can be read like there is a separate, not as reliable, way of fitting spectral cubes. We should instead say that we're using the same fitting procedure (minus the interactive UI bits) for the individual pixels on the cube as we do for normal spectra.

4. The main development work on pyspeckit is on GitHub, but there's no GitHub link in the paper! Let's either add it as a footnote in the abstract or in a separate Contributing section?

5. After "These requirements are frequently not satisfied; see Andrae et al. (2010) and Andrae (2010) for details." - should we close the section by saying that for the error estimation with the least assumptions made one could use mcmc methods in pyspeckit?