### PR TITLE
refactor to a more general executable path for pdflatex

### DIFF
--- a/make.py
+++ b/make.py
@@ -5,15 +5,17 @@ import glob
 import argparse
 import os
 import update_bibentries
+from distutils.spawn import find_executable
 
 assert os.path.exists('bibdesk.bib') or os.path.exists('extracted.bib')
 
 name = 'main'
+texpath = os.path.dirname(find_executable('pdflatex'))
 
 parser = argparse.ArgumentParser(description='Make latex files.')
 parser.add_argument('--referee', default=False,
                     action='store_true', help='referee style?')
-parser.add_argument('--texpath', default='/usr/texbin/',
+parser.add_argument('--texpath', default=texpath,
                     help='path to pdflatex')
 parser.add_argument('--infile', default=name+'.tex')
 parser.add_argument('--outfile', default='auto')


### PR DESCRIPTION
A rather minor improvement - the path to `pdflatex` executable under some Linux systems is not the one in the default args for the `make.py` file. Here we mimic the `which` functionality to optimize it (while staying within the standard python libs).